### PR TITLE
fix: harden qdrant restore script and align restore .env example

### DIFF
--- a/UPGRADE-OPERATIONS.md
+++ b/UPGRADE-OPERATIONS.md
@@ -737,11 +737,11 @@ nano .env
 # Qdrant API key
 export QDRANT_API_KEY="your-api-key-here"
 
-# Source hosts (where snapshots are stored)
-# Port forward qdrant service to local
-export QDRANT_SOURCE_HOSTS="http://localhost:6333"
+# Source hosts (leave empty for restore - collections are discovered from S3)
+export QDRANT_SOURCE_HOSTS=""
 
 # Restore hosts (target Qdrant instances)
+# Port forward qdrant service to local
 export QDRANT_RESTORE_HOSTS="http://localhost:6334"
 
 # S3 configuration (for fetching snapshots)

--- a/qdrant-backup-restore/k8s/configmap-script.yaml
+++ b/qdrant-backup-restore/k8s/configmap-script.yaml
@@ -112,6 +112,13 @@ data:
       local result="$2"
       _result=$(jq -c '.result.collections // [] | .[]' <<< "$result")
 
+      # Guard against the bash `<<<` quirk: a here-string of an empty value still
+      # produces a single newline, so the loop below would iterate once with an
+      # empty item and write a bogus `host,` line to $QDRANT_COLLECTIONS_FILE.
+      if [[ -z "$_result" ]]; then
+        return
+      fi
+
       while read -r item; do
         local collection_name=""
         collection_name=$(jq -r '.name' <<< "$item")
@@ -403,7 +410,7 @@ data:
       fi
 
       if [ ! -f "$QDRANT_COLLECTIONS_FILE" ]; then
-        _printf "non error exit since file does not %s exist.\n" "$QDRANT_COLLECTIONS_FILE"
+        _printf "non error exit since file %s does not exist.\n" "$QDRANT_COLLECTIONS_FILE"
         exit 0
       fi
 

--- a/qdrant-backup-restore/qdrant_backup_recovery.sh
+++ b/qdrant-backup-restore/qdrant_backup_recovery.sh
@@ -103,6 +103,13 @@ track_collection(){
   local result="$2"
   _result=$(jq -c '.result.collections // [] | .[]' <<< "$result")
 
+  # Guard against the bash `<<<` quirk: a here-string of an empty value still
+  # produces a single newline, so the loop below would iterate once with an
+  # empty item and write a bogus `host,` line to $QDRANT_COLLECTIONS_FILE.
+  if [[ -z "$_result" ]]; then
+    return
+  fi
+
   while read -r item; do
     local collection_name=""
     collection_name=$(jq -r '.name' <<< "$item")
@@ -394,7 +401,7 @@ generate_snapshot_file_from_s3() {
   fi
 
   if [ ! -f "$QDRANT_COLLECTIONS_FILE" ]; then
-    _printf "non error exit since file does not %s exist.\n" "$QDRANT_COLLECTIONS_FILE"
+    _printf "non error exit since file %s does not exist.\n" "$QDRANT_COLLECTIONS_FILE"
     exit 0
   fi
 


### PR DESCRIPTION
Follow-up to feat/auto-fetch-collections-from-s3 with three small fixes

- track_collection: skip the read loop when the jq result is empty. Bash here-strings always append a newline, so `done <<< ""` would otherwise iterate once with an empty item and write a bogus `host,` line to $QDRANT_COLLECTIONS_FILE. Affects `get_coll` against an empty source.
- generate_snapshot_file_from_s3: fix word order in the non-error exit message so the filename lands in the correct position.
- UPGRADE-OPERATIONS.md restore example: set QDRANT_SOURCE_HOSTS="" to match the new restore-from-S3-only contract used by the k8s manifests; move the port-forward note to QDRANT_RESTORE_HOSTS where it belongs.
- Sync configmap-script.yaml via config_map_updater.sh.